### PR TITLE
Fixing bugs

### DIFF
--- a/UOKiosk.xcodeproj/project.pbxproj
+++ b/UOKiosk.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		52153BBE28AF6584007F4812 /* MockEventsModelData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52153BBD28AF6584007F4812 /* MockEventsModelData.swift */; };
 		525538EC2A0D9979004BD415 /* EventsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525538EB2A0D9979004BD415 /* EventsViewModelTests.swift */; };
 		525538ED2A0DA5D1004BD415 /* MockApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525538E92A0C4CE3004BD415 /* MockApiService.swift */; };
+		525538F12A0ED0EE004BD415 /* CustomizeEventsFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525538F02A0ED0EE004BD415 /* CustomizeEventsFeedView.swift */; };
+		525538F32A0ED35C004BD415 /* CustomizeEventsFeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525538F22A0ED35C004BD415 /* CustomizeEventsFeedViewModel.swift */; };
 		528A2A192849C83F0035F416 /* EventsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528A2A182849C83F0035F416 /* EventsRepository.swift */; };
 		528A2A1D2849C9A30035F416 /* Injector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528A2A1C2849C9A30035F416 /* Injector.swift */; };
 		528A2A1F2849CA6E0035F416 /* ViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528A2A1E2849CA6E0035F416 /* ViewModelFactory.swift */; };
@@ -83,6 +85,8 @@
 		52153BBD28AF6584007F4812 /* MockEventsModelData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEventsModelData.swift; sourceTree = "<group>"; };
 		525538E92A0C4CE3004BD415 /* MockApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockApiService.swift; sourceTree = "<group>"; };
 		525538EB2A0D9979004BD415 /* EventsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsViewModelTests.swift; sourceTree = "<group>"; };
+		525538F02A0ED0EE004BD415 /* CustomizeEventsFeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeEventsFeedView.swift; sourceTree = "<group>"; };
+		525538F22A0ED35C004BD415 /* CustomizeEventsFeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeEventsFeedViewModel.swift; sourceTree = "<group>"; };
 		528A2A182849C83F0035F416 /* EventsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsRepository.swift; sourceTree = "<group>"; };
 		528A2A1C2849C9A30035F416 /* Injector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Injector.swift; sourceTree = "<group>"; };
 		528A2A1E2849CA6E0035F416 /* ViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelFactory.swift; sourceTree = "<group>"; };
@@ -146,6 +150,7 @@
 				52131E6028B54E58006C3094 /* EventsViewModel.swift */,
 				52131E6428B54E96006C3094 /* EventsViewModelDay.swift */,
 				52131E6228B54E6D006C3094 /* EventCellViewModel.swift */,
+				525538F22A0ED35C004BD415 /* CustomizeEventsFeedViewModel.swift */,
 			);
 			path = EventsViewModels;
 			sourceTree = "<group>";
@@ -308,6 +313,7 @@
 				529861E92845587C009C1E3B /* TabMenuView.swift */,
 				5299D4F128493B8B001FEDB5 /* EventsView.swift */,
 				52153BB328AED99D007F4812 /* EventCellView.swift */,
+				525538F02A0ED0EE004BD415 /* CustomizeEventsFeedView.swift */,
 				52153BAF28AE08EE007F4812 /* EventDetailView.swift */,
 			);
 			path = Views;
@@ -483,6 +489,8 @@
 				52131E6328B54E6D006C3094 /* EventCellViewModel.swift in Sources */,
 				528A2A192849C83F0035F416 /* EventsRepository.swift in Sources */,
 				52153BB028AE08EF007F4812 /* EventDetailView.swift in Sources */,
+				525538F32A0ED35C004BD415 /* CustomizeEventsFeedViewModel.swift in Sources */,
+				525538F12A0ED0EE004BD415 /* CustomizeEventsFeedView.swift in Sources */,
 				52131E4A28B31E85006C3094 /* EventFilter.swift in Sources */,
 				529861EC284558CD009C1E3B /* ApiService.swift in Sources */,
 				52131E6128B54E58006C3094 /* EventsViewModel.swift in Sources */,

--- a/UOKiosk/DependencyInjection/ViewModelFactory.swift
+++ b/UOKiosk/DependencyInjection/ViewModelFactory.swift
@@ -24,4 +24,8 @@ final class ViewModelFactory: ObservableObject {
     func makeEventsViewModel() -> EventsViewModel {
         EventsViewModel(eventsRepository: eventsRepository)
     }
+
+    func makeCustomizeEventsFeedViewModel() -> CustomizeEventsFeedViewModel {
+        CustomizeEventsFeedViewModel()
+    }
 }

--- a/UOKiosk/Models/EventModels/Event.swift
+++ b/UOKiosk/Models/EventModels/Event.swift
@@ -114,7 +114,6 @@ public class Event: NSManagedObject {
         self.targetAudienceFilters = []
         if let eventFilters = eventData.filters.eventTypes {
             for eventFilter in eventFilters {
-                // TODO: Does this work for adding items to an NSSet?
                 addToEventTypeFilters(EventFilter(id: eventFilter.id, name: eventFilter.name, context: context))
             }
         }

--- a/UOKiosk/Models/EventModels/Event.swift
+++ b/UOKiosk/Models/EventModels/Event.swift
@@ -73,7 +73,7 @@ public class Event: NSManagedObject {
         self.status = eventData.status ?? "live"
         self.experience = eventData.experience ?? "assumed inperson"
         
-        print(self.title ?? "Default title")
+//        print(self.title ?? "Default title")
         
         self.eventUrl = getUrl(urlString: eventData.localistUrl)
         self.streamUrl = getUrl(urlString: eventData.streamUrl)

--- a/UOKiosk/Repository/EventsRepository.swift
+++ b/UOKiosk/Repository/EventsRepository.swift
@@ -17,6 +17,7 @@ protocol EventsRepository {
      In the case of testing:
      - It will be used to make a mock repository for testing on local data not relying on a network connection
      */
+    func updateEventsResultsController(eventResultsController: NSFetchedResultsController<Event>) async throws
 
     func eventResultsController(with delegate: NSFetchedResultsControllerDelegate) -> NSFetchedResultsController<Event>?
 

--- a/UOKiosk/Repository/EventsRepository.swift
+++ b/UOKiosk/Repository/EventsRepository.swift
@@ -22,5 +22,5 @@ protocol EventsRepository {
 
     func fetchSavedEvents(with delegate: NSFetchedResultsControllerDelegate) -> NSFetchedResultsController<Event>?
 
-    func fetchNewEvents(eventResultsController: NSFetchedResultsController<Event>) async throws -> [Event]?
+    func saveFreshEvents(eventResultsController: NSFetchedResultsController<Event>) async throws -> [Event]?
 }

--- a/UOKiosk/Repository/EventsService.swift
+++ b/UOKiosk/Repository/EventsService.swift
@@ -146,7 +146,7 @@ final class EventsService: EventsRepository {
             // TODO: Often get the "Thread 2: EXC_BAD_ACCESS (code=1, address=0xfffffffffffffff8)" error here on first run of the application
             try persistentContainer.viewContext.save()
         } catch {
-            print("Failed to save viewContext, rolling back")
+//            print("Failed to save viewContext, rolling back")
             persistentContainer.viewContext.rollback()
         }
     }

--- a/UOKiosk/Repository/EventsService.swift
+++ b/UOKiosk/Repository/EventsService.swift
@@ -38,34 +38,7 @@ final class EventsService: EventsRepository {
         return fetchedResultsController
     }
 
-    func fetchNewEvents(eventResultsController: NSFetchedResultsController<Event>) async throws -> [Event]? {
-        func getEventInstanceDateData(dateData: EventInstanceDto) -> (Bool, Date, Date?) {
-            let startStr: String = dateData.start
-            let endStr: String? = dateData.end
-
-            // Format the start and end dates if they exist
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "y-M-d'T'HH:mm:ssZ"
-            let start: Date
-            let end: Date?
-
-            start = {
-                guard let date = dateFormatter.date(from: startStr) else {
-                    fatalError("Start date could not be determined form the provided date string")
-                }
-                return date
-            }()
-
-            if endStr != nil {
-                end = dateFormatter.date(from: endStr!)
-            } else {
-                end = nil
-            }
-
-            let allDay = dateData.allDay
-            return (allDay, start, end)
-        }
-
+    func saveFreshEvents(eventResultsController: NSFetchedResultsController<Event>) async throws -> [Event]? {
         var dto: EventsDto? = nil
         do {
             dto = try await ApiService.shared.getJSON(urlString: urlString)
@@ -127,6 +100,33 @@ final class EventsService: EventsRepository {
 
         return eventResultsController.fetchedObjects
         // TODO: Event in the eventsDto. Here the completion should take an array of event optional (ie. [Event]?) instead of EventsModel?
+    }
+
+    private func getEventInstanceDateData(dateData: EventInstanceDto) -> (Bool, Date, Date?) {
+        let startStr: String = dateData.start
+        let endStr: String? = dateData.end
+
+        // Format the start and end dates if they exist
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "y-M-d'T'HH:mm:ssZ"
+        let start: Date
+        let end: Date?
+
+        start = {
+            guard let date = dateFormatter.date(from: startStr) else {
+                fatalError("Start date could not be determined form the provided date string")
+            }
+            return date
+        }()
+
+        if endStr != nil {
+            end = dateFormatter.date(from: endStr!)
+        } else {
+            end = nil
+        }
+
+        let allDay = dateData.allDay
+        return (allDay, start, end)
     }
     
     func addEvent(eventDto: EventDto) {

--- a/UOKiosk/Repository/EventsService.swift
+++ b/UOKiosk/Repository/EventsService.swift
@@ -32,7 +32,6 @@ final class EventsService: EventsRepository {
                 continue
             }
 
-            // TODO: Bug: Because we are using GMT for time when we save events we need to adjust their time data to be in pacific time
             if start.compare(Date()) == ComparisonResult.orderedAscending {
                 deleteEvent(event)
             }

--- a/UOKiosk/Repository/EventsService.swift
+++ b/UOKiosk/Repository/EventsService.swift
@@ -28,8 +28,14 @@ final class EventsService: EventsRepository {
 
         // Delete any events that are before the current date
         for event in fetchedObjects {
+            // Delete object if it has no start date
+            guard let start = event.start else {
+                deleteEvent(event)
+                continue
+            }
+
             // TODO: Bug: Because we are using GMT for time when we save events we need to adjust their time data to be in pacific time
-            if event.start?.compare(Date()) == ComparisonResult.orderedAscending {
+            if start.compare(Date()) == ComparisonResult.orderedAscending {
                 deleteEvent(event)
             }
         }

--- a/UOKiosk/UOKioskApp.swift
+++ b/UOKiosk/UOKioskApp.swift
@@ -8,8 +8,9 @@ import SwiftUI
 
 @main
 struct UOKioskApp: App {
+    // FIXME: This url does not show recurring events. Add an option for allowing recurring events in a settings page on the app
     let injector = Injector(eventsRepository: EventsService(urlString: "https://calendar.uoregon.edu/api/2/events?days=90&recurring=false&pp=100"))
-    
+
     var body: some Scene {
         WindowGroup {
             TabMenuView(injector: injector)

--- a/UOKiosk/ViewModels/EventsViewModels/CustomizeEventsFeedViewModel.swift
+++ b/UOKiosk/ViewModels/EventsViewModels/CustomizeEventsFeedViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  CustomizeEventsFeedViewModel.swift
+//  UOKiosk
+//
+//  Created by Jonathan Paul on 5/12/23.
+//
+
+import Foundation
+
+final class CustomizeEventsFeedViewModel {
+    
+}

--- a/UOKiosk/ViewModels/EventsViewModels/EventCellViewModel.swift
+++ b/UOKiosk/ViewModels/EventsViewModels/EventCellViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by Jonathan Paul on 8/23/22.
 //
 
-import Foundation
 import UIKit
 
 final class EventCellViewModel: ObservableObject, Identifiable, Hashable {

--- a/UOKiosk/ViewModels/EventsViewModels/EventsViewModel.swift
+++ b/UOKiosk/ViewModels/EventsViewModels/EventsViewModel.swift
@@ -47,7 +47,7 @@ final class EventsViewModel: NSObject, ObservableObject, Identifiable, NSFetched
         self.resultsController = eventsRepository.fetchSavedEvents(with: self)
         
         #if DEBUG
-        print("On instantiation of the EventsViewModel the value loaded in for the last data update date is \(lastDataUpdateDate).")
+//        print("On instantiation of the EventsViewModel the value loaded in for the last data update date is \(lastDataUpdateDate).")
         #endif
     }
     
@@ -105,7 +105,7 @@ final class EventsViewModel: NSObject, ObservableObject, Identifiable, NSFetched
             // TODO: Add error handling here: The showAlert bool and message are already set up. Just need to show the error
             showAlert = true
             errorMessage = error.localizedDescription + " No Events were returned from the events repository fetchNewEvents method"
-            print("No Events were returned from the events repository fetchNewEvents method")
+//            print("No Events were returned from the events repository fetchNewEvents method")
             return
         }
         self.fillData()

--- a/UOKiosk/ViewModels/EventsViewModels/EventsViewModel.swift
+++ b/UOKiosk/ViewModels/EventsViewModels/EventsViewModel.swift
@@ -123,6 +123,7 @@ final class EventsViewModel: NSObject, ObservableObject, Identifiable, NSFetched
                 guard let start = event.start else {
                     continue // TODO: For now, skip the event if it has no start time
                 }
+
                 let currDateString: String = start.formatted(date: .abbreviated, time: .omitted)
 
                 // If the last date we save is not the same as the current date, then start a new day

--- a/UOKiosk/ViewModels/EventsViewModels/EventsViewModel.swift
+++ b/UOKiosk/ViewModels/EventsViewModels/EventsViewModel.swift
@@ -100,7 +100,7 @@ final class EventsViewModel: NSObject, ObservableObject, Identifiable, NSFetched
             return
         }
         do {
-            try await eventsRepository.fetchNewEvents(eventResultsController: resultsController)
+            try await eventsRepository.saveFreshEvents(eventResultsController: resultsController)
         } catch {
             // TODO: Add error handling here: The showAlert bool and message are already set up. Just need to show the error
             showAlert = true

--- a/UOKiosk/ViewModels/EventsViewModels/EventsViewModel.swift
+++ b/UOKiosk/ViewModels/EventsViewModels/EventsViewModel.swift
@@ -100,7 +100,8 @@ final class EventsViewModel: NSObject, ObservableObject, Identifiable, NSFetched
             return
         }
         do {
-            try await eventsRepository.saveFreshEvents(eventResultsController: resultsController)
+            try await eventsRepository.updateEventsResultsController(eventResultsController: resultsController)
+            //try await eventsRepository.saveFreshEvents(eventResultsController: resultsController)
         } catch {
             // TODO: Add error handling here: The showAlert bool and message are already set up. Just need to show the error
             showAlert = true

--- a/UOKiosk/Views/CustomizeEventsFeedView.swift
+++ b/UOKiosk/Views/CustomizeEventsFeedView.swift
@@ -1,0 +1,25 @@
+//
+//  CustomizeEventsFeedView.swift
+//  UOKiosk
+//
+//  Created by Jonathan Paul on 5/12/23.
+//
+import SwiftUI
+
+struct CustomizeEventsFeedView: View {
+    let vm: CustomizeEventsFeedViewModel
+
+    var body: some View {
+        VStack {
+            Text("HI")
+        }
+    }
+}
+
+#if DEBUG
+struct CustomizeEventsFeedView_Previews: PreviewProvider {
+    static var previews: some View {
+        CustomizeEventsFeedView(vm: CustomizeEventsFeedViewModel())
+    }
+}
+#endif

--- a/UOKiosk/Views/EventsView.swift
+++ b/UOKiosk/Views/EventsView.swift
@@ -5,7 +5,6 @@
 //  Created by Jonathan Paul on 6/2/22.
 //
 
-import Foundation
 import SwiftUI
 
 struct EventsView: View {
@@ -21,30 +20,36 @@ struct EventsView: View {
     }
     
     var body: some View {
-        List {
-            ForEach(viewModel.eventsInADay) { eventsInADay in
-                Section {
-                    ForEach(eventsInADay.events) { event in
-                        NavigationLink {
-                            EventDetailView(event.eventModel, injector: self.injector)
-                        } label: {
-                            EventCellView(event: event)
+        VStack {
+            Button("Customize Feed") {
+                // TODO: Segue to a modal view for customizing the feed.
+                
+            }
+            List {
+                ForEach(viewModel.eventsInADay) { eventsInADay in
+                    Section {
+                        ForEach(eventsInADay.events) { event in
+                            NavigationLink {
+                                EventDetailView(event.eventModel, injector: self.injector)
+                            } label: {
+                                EventCellView(event: event)
+                            }
                         }
+                    } header: {
+                        Text("\(eventsInADay.dateString)")
+                            .font(.title)
                     }
-                } header: {
-                    Text("\(eventsInADay.dateString)")
-                        .font(.title)
                 }
             }
-        }
-        .task {
-            if !didLoad {
-                didLoad = true
-                await viewModel.fetchEvents(shouldCheckLastUpdateDate: true)
+            .task {
+                if !didLoad {
+                    didLoad = true
+                    await viewModel.fetchEvents(shouldCheckLastUpdateDate: true)
+                }
             }
+            .refreshable {
+                await viewModel.fetchEvents()
         }
-        .refreshable {
-            await viewModel.fetchEvents()
         }
     }
 }

--- a/UOKiosk/Views/EventsView.swift
+++ b/UOKiosk/Views/EventsView.swift
@@ -19,7 +19,7 @@ struct EventsView: View {
         // Set the var StateObject<EventsViewModel>
         _viewModel = StateObject(wrappedValue: injector.viewModelFactory.makeEventsViewModel())
     }
-    
+
     var body: some View {
         VStack {
             Button("Customize Feed") {

--- a/UOKiosk/Views/EventsView.swift
+++ b/UOKiosk/Views/EventsView.swift
@@ -11,6 +11,7 @@ struct EventsView: View {
     let injector: Injector
     @StateObject var viewModel: EventsViewModel
     @State private var didLoad = false
+    @State private var showCustomizeFeedView = false
     
     // MARK: INITIALIZERS
     init(injector: Injector) {
@@ -22,8 +23,9 @@ struct EventsView: View {
     var body: some View {
         VStack {
             Button("Customize Feed") {
-                // TODO: Segue to a modal view for customizing the feed.
-                
+                showCustomizeFeedView = true
+            }.sheet(isPresented: $showCustomizeFeedView) {
+                CustomizeEventsFeedView(vm: injector.viewModelFactory.makeCustomizeEventsFeedViewModel())
             }
             List {
                 ForEach(viewModel.eventsInADay) { eventsInADay in

--- a/UOKiosk/Views/EventsView.swift
+++ b/UOKiosk/Views/EventsView.swift
@@ -22,11 +22,11 @@ struct EventsView: View {
 
     var body: some View {
         VStack {
-            Button("Customize Feed") {
-                showCustomizeFeedView = true
-            }.sheet(isPresented: $showCustomizeFeedView) {
-                CustomizeEventsFeedView(vm: injector.viewModelFactory.makeCustomizeEventsFeedViewModel())
-            }
+//            Button("Customize Feed") {
+//                showCustomizeFeedView = true
+//            }.sheet(isPresented: $showCustomizeFeedView) {
+//                CustomizeEventsFeedView(vm: injector.viewModelFactory.makeCustomizeEventsFeedViewModel())
+//            }
             List {
                 ForEach(viewModel.eventsInADay) { eventsInADay in
                     Section {

--- a/UOKiosk/Views/TabMenuView.swift
+++ b/UOKiosk/Views/TabMenuView.swift
@@ -27,6 +27,7 @@ struct TabMenuView: View {
                 EventsView(injector: injector)
                     .navigationTitle("Events")
             }
+            .navigationViewStyle(StackNavigationViewStyle())
             .tag(Tabs.events)
             .tabItem {
                 Image(systemName: "calendar")

--- a/UOKioskTests/Mocks/MockRepository/MockEventsService.swift
+++ b/UOKioskTests/Mocks/MockRepository/MockEventsService.swift
@@ -10,6 +10,10 @@ import CoreData
 
 
 final class MockEventsService: EventsRepository {
+
+    func updateEventsResultsController(eventResultsController: NSFetchedResultsController<Event>) async throws {
+    }
+
     func eventResultsController(with delegate: NSFetchedResultsControllerDelegate) -> NSFetchedResultsController<Event>? {
         return nil
     }

--- a/UOKioskTests/Mocks/MockRepository/MockEventsService.swift
+++ b/UOKioskTests/Mocks/MockRepository/MockEventsService.swift
@@ -18,7 +18,7 @@ final class MockEventsService: EventsRepository {
         return nil
     }
 
-    func fetchNewEvents(eventResultsController: NSFetchedResultsController<Event>) async throws -> [Event]? {
+    func saveFreshEvents(eventResultsController: NSFetchedResultsController<Event>) async throws -> [Event]? {
         /* TODO
          2 ways to do this:
             1. Hard code a bunch of events and return them


### PR DESCRIPTION
Events list shows on the Events tab now on iPad. Before, the list was appearing in the sidebar.
There is no longer a discrepancy in the events shown on opening the app and loading core data store vs. polling for fresh data from the Web API.
Added in code for a button to "Customize Feed" (filter the events data) and created a view and view-model for that filtering. Have not yet implemented the actual filtering. Commented out the button that says "Customize Feed" as it is not functional yet.